### PR TITLE
Unify Translation of "packfile"

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6349,11 +6349,11 @@ msgstr "--fix-thin 不能和 --stdin 同时使用"
 #: builtin/index-pack.c:1707 builtin/index-pack.c:1716
 #, c-format
 msgid "packfile name '%s' does not end with '.pack'"
-msgstr "包名 '%s' 没有以 '.pack' 结尾"
+msgstr "包文件名 '%s' 没有以 '.pack' 结尾"
 
 #: builtin/index-pack.c:1724
 msgid "--verify with no packfile name given"
-msgstr "--verify 没有提供包名参数"
+msgstr "--verify 没有提供包文件名参数"
 
 #: builtin/init-db.c:35
 #, c-format
@@ -9004,7 +9004,7 @@ msgstr "限制最大增量深度"
 
 #: builtin/repack.c:185
 msgid "maximum size of each packfile"
-msgstr "每个包的最大尺寸"
+msgstr "每个包文件的最大尺寸"
 
 #: builtin/repack.c:187
 msgid "repack objects in packs marked with .keep"


### PR DESCRIPTION
All "packfile" translated as "包文件".
