### PR TITLE
l10n: zh_CN: Add translations for Git glossary

### DIFF
--- a/po/TEAMS
+++ b/po/TEAMS
@@ -53,10 +53,4 @@ Members:	Nguyễn Thái Ngọc Duy <pclouds AT gmail.com>
 Language:	zh_CN (Simplified Chinese)
 Repository:	https://github.com/jiangxin/git/
 Leader:		Jiang Xin <worldhello.net@gmail.com>
-Members:	Riku <lu.riku AT gmail.com>
-		Zhuang Ya <zhuangya AT me.com>
-		Lian Cheng <rhythm.mail AT gmail.com>
-		Yichao Yu <yyc1992 AT gmail.com>
-		ws3389 <willsmith3389 AT gmail.com>
-		Thynson <lanxingcan AT gmail.com>
-		Wang Sheng <wangsheng2008love@163.com>
+Members:	Ray Chen <oldsharp@gmail.com>

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4,16 +4,21 @@
 # This file is distributed under the same license as the Git package.
 # Contributors:
 #   - Jiang Xin <worldhello.net AT gmail.com>
-#   - Riku <lu.riku AT gmail.com>
-#   - Zhuang Ya <zhuangya AT me.com>
 #   - Lian Cheng <rhythm.mail AT gmail.com>
+#   - Ray Chen <oldsharp AT gmail.com>
+#   - Riku <lu.riku AT gmail.com>
+#   - Thynson <lanxingcan AT gmail.com>
+#   - ws3389 <willsmith3389 AT gmail.com>
+#   - Wang Sheng <wangsheng2008love AT 163.com>
+#   - Yichao Yu <yyc1992 AT gmail.com>
+#   - Zhuang Ya <zhuangya AT me.com>
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
 "POT-Creation-Date: 2015-07-14 07:19+0800\n"
-"PO-Revision-Date: 2015-07-30 23:41+0800\n"
+"PO-Revision-Date: 2015-08-04 00:42+0800\n"
 "Last-Translator: Jiang Xin <worldhello.net@gmail.com>\n"
 "Language-Team: GitHub <https://github.com/jiangxin/git/>\n"
 "Language: zh_CN\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,12 +13,128 @@
 #   - Yichao Yu <yyc1992 AT gmail.com>
 #   - Zhuang Ya <zhuangya AT me.com>
 #
+#  Git glossary for Chinese translators
+#
+#   English                          |  Chinese
+#   ---------------------------------+--------------------------------------
+#   3-way merge                      |  三方合并
+#   abbreviate                       |  简写（的 SHA-1 值）
+#   alternate object database        |  备用对象库
+#   amend                            |  修补
+#   ancestor                         |  祖先，祖先提交
+#   annotated tag                    |  附注标签
+#   bare repository                  |  纯仓库
+#   bisect                           |  二分查找
+#   blob object                      |  数据对象
+#   branch                           |  分支
+#   bundle                           |  包
+#   bypass                           |  绕过
+#   cache                            |  索引（的别称）
+#   chain                            |  （提交）链
+#   changeset                        |  变更集
+#   checkout                         |  检出
+#   checksum                         |  校验，校验和
+#   cherry-picking                   |  拣选
+#   clean                            |  干净（的工作区）
+#   clone                            |  克隆
+#   commit                           |  提交
+#   commit object                    |  提交对象
+#   commit-ish (also committish)     |  提交号
+#   conflict                         |  冲突
+#   core Git                         |  核心 Git 工具
+#   DAG                              |  有向无环图
+#   dangling object                  |  摇摆对象
+#   detached HEAD                    |  分离头指针
+#   directory                        |  目录
+#   dirty                            |  脏（的工作区）
+#   dumb HTTP                        |  哑 HTTP 协议
+#   evil merge                       |  坏合并（合并引入了父提交没有的修改）
+#   fast-forward                     |  快进
+#   fetch                            |  获取
+#   file system                      |  文件系统
+#   fork                             |  派生，复刻
+#   Git archive                      |  仓库（对于 arch 用户）
+#   gitfile                          |  gitfile（仓库链接文件）
+#   grafts                           |  （提交）嫁接
+#   hash                             |  哈希值
+#   HEAD                             |  HEAD（头指针，亦即当前分支）
+#   head                             |  头、分支
+#   head ref                         |  分支
+#   header                           |  头信息
+#   hook                             |  钩子
+#   hunk                             |  补丁片段
+#   index                            |  索引
+#   index entry                      |  索引条目
+#   loose object                     |  松散对象
+#   loose refs                       |  松散引用
+#   master                           |  master（默认分支名）
+#   merge                            |  合并
+#   object                           |  对象
+#   object database                  |  对象库
+#   object identifier                |  对象标识符
+#   object name                      |  对象名称
+#   object type                      |  对象类型
+#   octopus                          |  章鱼式合并（两分支以上的合并）
+#   origin                           |  origin（默认的远程名称）
+#   pack                             |  包
+#   pack index                       |  包索引
+#   packfile                         |  包文件
+#   parent                           |  父提交
+#   patch                            |  补丁
+#   pathspec                         |  路径规格
+#   pattern                          |  模式
+#   pickaxe                          |  pickaxe
+#   plumbing                         |  管件（Git 底层核心命令的别称）
+#   porcelain                        |  瓷件（Git 上层封装命令的别称）
+#   prune                            |  清除
+#   pull                             |  拉，拉取
+#   push                             |  推，推送
+#   reachable                        |  可达
+#   rebase                           |  变基
+#   ref                              |  引用
+#   reflog                           |  引用日志
+#   refspec                          |  引用规格
+#   remote                           |  远程，远程仓库
+#   remote-tracking branch           |  远程跟踪分支
+#   replay                           |  重放
+#   repo                             |  仓库
+#   repository                       |  仓库
+#   resolve                          |  （冲突）解决
+#   revert                           |  还原
+#   revision                         |  版本
+#   rewind                           |  回退
+#   SCM                              |  源代码管理（工具）
+#   SHA-1                            |  安全哈希算法1
+#   shallow repository               |  浅（克隆）仓库
+#   signed tag                       |  签名标签
+#   smart HTTP                       |  智能 HTTP 协议
+#   squash                           |  压缩
+#   stage                            |  n. 暂存区（即索引）; v. 暂存
+#   stash                            |  n. 进度保存; v. 保存进度
+#   submodule                        |  子模组
+#   symref                           |  符号引用
+#   tag                              |  标签
+#   tag object                       |  标签对象
+#   tagger                           |  打标签者
+#   topic branch                     |  主题分支
+#   track                            |  跟踪
+#   tree                             |  树（工作区或树对象）
+#   tree object                      |  树对象
+#   tree-ish (also treeish)          |  树对象（或可以解析为一树对象）
+#   unmerged index                   |  未合并索引
+#   unpack                           |  解包
+#   unreachable object               |  不可达对象
+#   unstage                          |  取消暂存
+#   upstream                         |  上游
+#   upstream branch                  |  上游分支
+#   working tree                     |  工作区
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
 "POT-Creation-Date: 2015-07-14 07:19+0800\n"
-"PO-Revision-Date: 2015-08-04 00:42+0800\n"
+"PO-Revision-Date: 2015-08-04 00:43+0800\n"
 "Last-Translator: Jiang Xin <worldhello.net@gmail.com>\n"
 "Language-Team: GitHub <https://github.com/jiangxin/git/>\n"
 "Language: zh_CN\n"
@@ -52,16 +168,16 @@ msgstr "git archive --list"
 msgid ""
 "git archive --remote <repo> [--exec <cmd>] [<options>] <tree-ish> [<path>...]"
 msgstr ""
-"git archive --remote <版本库> [--exec <命令>] [<选项>] <树或提交> [<路径>...]"
+"git archive --remote <仓库> [--exec <命令>] [<选项>] <树或提交> [<路径>...]"
 
 #: archive.c:14
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
-msgstr "git archive --remote <版本库> [--exec <命令>] --list"
+msgstr "git archive --remote <仓库> [--exec <命令>] --list"
 
 #: archive.c:342 builtin/add.c:137 builtin/add.c:428 builtin/rm.c:327
 #, c-format
 msgid "pathspec '%s' did not match any files"
-msgstr "路径规则 '%s' 未匹配任何文件"
+msgstr "路径规格 '%s' 未匹配任何文件"
 
 #: archive.c:427
 msgid "fmt"
@@ -117,11 +233,11 @@ msgstr "列出支持的归档格式"
 
 #: archive.c:449 builtin/archive.c:90 builtin/clone.c:77
 msgid "repo"
-msgstr "版本库"
+msgstr "仓库"
 
 #: archive.c:450 builtin/archive.c:91
 msgid "retrieve the archive from remote repository <repo>"
-msgstr "从远程版本库（<版本库>）提取归档文件"
+msgstr "从远程仓库（<仓库>）提取归档文件"
 
 #: archive.c:451 builtin/archive.c:92 builtin/notes.c:478
 msgid "command"
@@ -263,7 +379,7 @@ msgstr "不能打开 '%s'"
 
 #: bundle.c:139
 msgid "Repository lacks these prerequisite commits:"
-msgstr "版本库缺少这些必备的提交："
+msgstr "仓库中缺少这些必备的提交："
 
 #: bundle.c:163 sequencer.c:650 sequencer.c:1105 builtin/blame.c:2705
 #: builtin/branch.c:651 builtin/commit.c:1045 builtin/log.c:330
@@ -704,7 +820,7 @@ msgstr "不能读取对象 %s '%s'"
 #: merge-recursive.c:765
 #, c-format
 msgid "blob expected for %s '%s'"
-msgstr "%s '%s' 应为数据（blob）对象"
+msgstr "%s '%s' 应为数据对象"
 
 #: merge-recursive.c:788 builtin/clone.c:306
 #, c-format
@@ -813,7 +929,7 @@ msgstr "不能读取对象 %s"
 #: merge-recursive.c:1527
 #, c-format
 msgid "object %s is not a blob"
-msgstr "对象 %s 不是一个数据（blob）对象"
+msgstr "对象 %s 不是一个数据对象"
 
 #: merge-recursive.c:1575
 msgid "modify"
@@ -969,32 +1085,32 @@ msgstr "-数字"
 
 #: pathspec.c:133
 msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
-msgstr "全局的 'glob' 和 'noglob' 路径规则设置不兼容"
+msgstr "全局的 'glob' 和 'noglob' 路径规格设置不兼容"
 
 #: pathspec.c:143
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
-msgstr "全局的 'literal' 路径规则设置和其它的全局路径规则设置不兼容"
+msgstr "全局的 'literal' 路径规格设置和其它的全局路径规格设置不兼容"
 
 #: pathspec.c:177
 msgid "invalid parameter for pathspec magic 'prefix'"
-msgstr "路径规则包含无效的神奇前缀"
+msgstr "路径规格包含无效的神奇前缀"
 
 #: pathspec.c:183
 #, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
-msgstr "在路径规则 '%3$s' 中无效的神奇前缀 '%2$.*1$s'"
+msgstr "在路径规格 '%3$s' 中无效的神奇前缀 '%2$.*1$s'"
 
 #: pathspec.c:187
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
-msgstr "路径规则 '%s' 的神奇前缀结尾少了一个 ')'"
+msgstr "路径规格 '%s' 的神奇前缀结尾少了一个 ')'"
 
 #: pathspec.c:205
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
-msgstr "路径规则 '%2$s' 中包含未实现的神奇前缀 '%1$c'"
+msgstr "路径规格 '%2$s' 中包含未实现的神奇前缀 '%1$c'"
 
 #: pathspec.c:230
 #, c-format
@@ -1004,22 +1120,22 @@ msgstr "%s：'literal' 和 'glob' 不兼容"
 #: pathspec.c:241
 #, c-format
 msgid "%s: '%s' is outside repository"
-msgstr "%s：'%s' 在版本库之外"
+msgstr "%s：'%s' 在仓库之外"
 
 #: pathspec.c:291
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
-msgstr "路径规则 '%s' 在子模组 '%.*s' 中"
+msgstr "路径规格 '%s' 在子模组 '%.*s' 中"
 
 #: pathspec.c:353
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
-msgstr "%s：路径规则神奇前缀不被此命令支持：%s"
+msgstr "%s：路径规格神奇前缀不被此命令支持：%s"
 
 #: pathspec.c:432
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
-msgstr "路径规则 '%s' 位于符号链接中"
+msgstr "路径规格 '%s' 位于符号链接中"
 
 #: pathspec.c:441
 msgid ""
@@ -1106,7 +1222,7 @@ msgstr "分支 '%s' 没有设置要推送的远程服务器"
 #: remote.c:1782
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
-msgstr "向 '%s' 推送引用表达式未包含 '%s'"
+msgstr "向 '%s' 推送引用规格未包含 '%s'"
 
 #: remote.c:1795
 msgid "push has no destination (push.default is 'nothing')"
@@ -2046,7 +2162,7 @@ msgstr "无法删除 '%s'"
 
 #: builtin/add.c:22
 msgid "git add [<options>] [--] <pathspec>..."
-msgstr "git add [<选项>] [--] <路径规则>..."
+msgstr "git add [<选项>] [--] <路径规格>..."
 
 #: builtin/add.c:65
 #, c-format
@@ -2589,7 +2705,7 @@ msgstr "还应用此补丁（与 --stat/--summary/--check 选项同时使用）"
 
 #: builtin/apply.c:4555
 msgid "attempt three-way merge if a patch does not apply"
-msgstr "如果一个补丁不能应用则尝试三路合并"
+msgstr "如果一个补丁不能应用则尝试三方合并"
 
 #: builtin/apply.c:4557
 msgid "build a temporary index based on embedded index information"
@@ -2649,15 +2765,15 @@ msgstr "为所有文件名前添加 <根目录>"
 
 #: builtin/apply.c:4610
 msgid "--3way outside a repository"
-msgstr "--3way 在一个版本库之外"
+msgstr "--3way 在一个仓库之外"
 
 #: builtin/apply.c:4618
 msgid "--index outside a repository"
-msgstr "--index 在一个版本库之外"
+msgstr "--index 在一个仓库之外"
 
 #: builtin/apply.c:4621
 msgid "--cached outside a repository"
-msgstr "--cached 在一个版本库之外"
+msgstr "--cached 在一个仓库之外"
 
 #: builtin/apply.c:4640
 #, c-format
@@ -3257,11 +3373,11 @@ msgstr "%s 可以\n"
 
 #: builtin/bundle.c:64
 msgid "Need a repository to create a bundle."
-msgstr "需要一个版本库来创建包。"
+msgstr "需要一个仓库来创建包。"
 
 #: builtin/bundle.c:68
 msgid "Need a repository to unbundle."
-msgstr "需要一个版本库来解包。"
+msgstr "需要一个仓库来解包。"
 
 #: builtin/cat-file.c:369
 msgid ""
@@ -3300,7 +3416,7 @@ msgstr "美观地打印对象的内容"
 
 #: builtin/cat-file.c:414
 msgid "for blob objects, run textconv on object's content"
-msgstr "对于数据（blob）对象，对其内容执行 textconv"
+msgstr "对于数据对象，对其内容执行 textconv"
 
 #: builtin/cat-file.c:416
 msgid "allow -s and -t to work with broken/corrupt objects"
@@ -3694,7 +3810,7 @@ msgstr "强制检出（丢弃本地修改）"
 
 #: builtin/checkout.c:1217
 msgid "perform a 3-way merge with the new branch"
-msgstr "和新的分支执行三路合并"
+msgstr "和新的分支执行三方合并"
 
 #: builtin/checkout.c:1218 builtin/merge.c:227
 msgid "update ignored files (default)"
@@ -3776,12 +3892,12 @@ msgstr "将删除 %s\n"
 #: builtin/clean.c:32
 #, c-format
 msgid "Skipping repository %s\n"
-msgstr "忽略版本库 %s\n"
+msgstr "忽略仓库 %s\n"
 
 #: builtin/clean.c:33
 #, c-format
 msgid "Would skip repository %s\n"
-msgstr "将忽略版本库 %s\n"
+msgstr "将忽略仓库 %s\n"
 
 #: builtin/clean.c:34
 #, c-format
@@ -3938,7 +4054,7 @@ msgstr ""
 
 #: builtin/clone.c:37
 msgid "git clone [<options>] [--] <repo> [<dir>]"
-msgstr "git clone [<选项>] [--] <版本库> [<路径>]"
+msgstr "git clone [<选项>] [--] <仓库> [<路径>]"
 
 #: builtin/clone.c:57 builtin/fetch.c:111 builtin/merge.c:224
 #: builtin/push.c:523
@@ -3951,15 +4067,15 @@ msgstr "不创建一个检出"
 
 #: builtin/clone.c:60 builtin/clone.c:62 builtin/init-db.c:503
 msgid "create a bare repository"
-msgstr "创建一个纯版本库"
+msgstr "创建一个纯仓库"
 
 #: builtin/clone.c:64
 msgid "create a mirror repository (implies bare)"
-msgstr "创建一个镜像版本库（也是纯版本库）"
+msgstr "创建一个镜像仓库（也是纯仓库）"
 
 #: builtin/clone.c:66
 msgid "to clone from a local repository"
-msgstr "从本地版本库克隆"
+msgstr "从本地仓库克隆"
 
 #: builtin/clone.c:68
 msgid "don't use local hardlinks, always copy"
@@ -3967,7 +4083,7 @@ msgstr "不使用本地硬链接，始终复制"
 
 #: builtin/clone.c:70
 msgid "setup as shared repository"
-msgstr "设置为共享版本库"
+msgstr "设置为共享仓库"
 
 #: builtin/clone.c:72 builtin/clone.c:74
 msgid "initialize submodules in the clone"
@@ -3983,11 +4099,11 @@ msgstr "模板目录将被使用"
 
 #: builtin/clone.c:78
 msgid "reference repository"
-msgstr "参考版本库"
+msgstr "参考仓库"
 
 #: builtin/clone.c:80
 msgid "use --reference only while cloning"
-msgstr "仅在克隆时参考 --reference 指向的本地版本库"
+msgstr "仅在克隆时参考 --reference 指向的本地仓库"
 
 #: builtin/clone.c:81 builtin/column.c:26 builtin/merge-file.c:44
 msgid "name"
@@ -4031,22 +4147,22 @@ msgstr "key=value"
 
 #: builtin/clone.c:94
 msgid "set config inside the new repository"
-msgstr "在新版本库中设置配置信息"
+msgstr "在新仓库中设置配置信息"
 
 #: builtin/clone.c:240
 #, c-format
 msgid "reference repository '%s' is not a local repository."
-msgstr "参考版本库 '%s' 不是一个本地版本库。"
+msgstr "参考仓库 '%s' 不是一个本地仓库。"
 
 #: builtin/clone.c:244
 #, c-format
 msgid "reference repository '%s' is shallow"
-msgstr "参考版本库 '%s' 是一个浅克隆"
+msgstr "参考仓库 '%s' 是一个浅克隆"
 
 #: builtin/clone.c:247
 #, c-format
 msgid "reference repository '%s' is grafted"
-msgstr "参考版本库 '%s' 已被嫁接"
+msgstr "参考仓库 '%s' 已被嫁接"
 
 #: builtin/clone.c:310
 #, c-format
@@ -4129,7 +4245,7 @@ msgstr "太多参数。"
 
 #: builtin/clone.c:767
 msgid "You must specify a repository to clone."
-msgstr "您必须指定一个版本库来克隆。"
+msgstr "您必须指定一个仓库来克隆。"
 
 #: builtin/clone.c:778
 #, c-format
@@ -4143,7 +4259,7 @@ msgstr "--bare 和 --separate-git-dir 选项不兼容。"
 #: builtin/clone.c:794
 #, c-format
 msgid "repository '%s' does not exist"
-msgstr "版本库 '%s' 不存在"
+msgstr "仓库 '%s' 不存在"
 
 #: builtin/clone.c:800 builtin/fetch.c:1160
 #, c-format
@@ -4174,7 +4290,7 @@ msgstr "不能创建工作区目录 '%s'"
 #: builtin/clone.c:856
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
-msgstr "克隆到纯版本库 '%s'...\n"
+msgstr "克隆到纯仓库 '%s'...\n"
 
 #: builtin/clone.c:858
 #, c-format
@@ -4191,7 +4307,7 @@ msgstr "--depth 在本地克隆被忽略，改为 file:// 协议试试。"
 
 #: builtin/clone.c:903
 msgid "source repository is shallow, ignoring --local"
-msgstr "源版本库是浅克隆，忽略 --local"
+msgstr "源仓库是浅克隆，忽略 --local"
 
 #: builtin/clone.c:908
 msgid "--local is ignored"
@@ -4209,7 +4325,7 @@ msgstr "远程分支 %s 在上游 %s 未发现"
 
 #: builtin/clone.c:972
 msgid "You appear to have cloned an empty repository."
-msgstr "您似乎克隆了一个空版本库。"
+msgstr "您似乎克隆了一个空仓库。"
 
 #: builtin/column.c:9
 msgid "git column [<options>]"
@@ -4245,11 +4361,11 @@ msgstr "--command 必须是第一个参数"
 
 #: builtin/commit.c:37
 msgid "git commit [<options>] [--] <pathspec>..."
-msgstr "git commit [<选项>] [--] <路径规则>..."
+msgstr "git commit [<选项>] [--] <路径规格>..."
 
 #: builtin/commit.c:42
 msgid "git status [<options>] [--] <pathspec>..."
-msgstr "git status [<选项>] [--] <路径规则>..."
+msgstr "git status [<选项>] [--] <路径规格>..."
 
 #: builtin/commit.c:47
 msgid ""
@@ -4580,7 +4696,7 @@ msgstr "参数 --include/--only 不跟路径没有意义。"
 
 #: builtin/commit.c:1195
 msgid "Clever... amending the last one with dirty index."
-msgstr "聪明... 在索引不干净下修补最后的提交。"
+msgstr "聪明... 用脏索引修补最后一个提交。"
 
 #: builtin/commit.c:1197
 msgid "Explicit paths specified without -i or -o; assuming --only paths..."
@@ -4846,7 +4962,7 @@ msgid ""
 "new_index file. Check that disk is not full and quota is\n"
 "not exceeded, and then \"git reset HEAD\" to recover."
 msgstr ""
-"版本库已更新，但无法写 new_index 文件。检查是否磁盘已满\n"
+"仓库已更新，但无法写 new_index 文件。检查是否磁盘已满\n"
 "或磁盘配额已耗尽，然后执行 \"git reset HEAD\" 恢复。"
 
 #: builtin/config.c:8
@@ -4867,7 +4983,7 @@ msgstr "使用系统级配置文件"
 
 #: builtin/config.c:56
 msgid "use repository config file"
-msgstr "使用版本库级配置文件"
+msgstr "使用仓库级配置文件"
 
 #: builtin/config.c:57
 msgid "use given config file"
@@ -4975,7 +5091,7 @@ msgstr "查询时参照 include 指令递归查找"
 
 #: builtin/config.c:316
 msgid "unable to parse default color value"
-msgstr "不能解析缺省的颜色值"
+msgstr "不能解析默认颜色值"
 
 #: builtin/config.c:457
 #, c-format
@@ -5131,7 +5247,7 @@ msgstr "标记"
 
 #: builtin/describe.c:412
 msgid "append <mark> on dirty working tree (default: \"-dirty\")"
-msgstr "若工作区脏（有变更）在结尾添加 <标记>（默认：\"-dirty\"）"
+msgstr "对于脏工作区，追加 <标记>（默认：\"-dirty\"）"
 
 #: builtin/describe.c:430
 msgid "--long is incompatible with --abbrev=0"
@@ -5157,7 +5273,7 @@ msgstr "无效选项：%s"
 
 #: builtin/diff.c:358
 msgid "Not a git repository"
-msgstr "不是一个 git 版本库"
+msgstr "不是一个 git 仓库"
 
 #: builtin/diff.c:401
 #, c-format
@@ -5167,7 +5283,7 @@ msgstr "提供了无效对象 '%s'。"
 #: builtin/diff.c:410
 #, c-format
 msgid "more than two blobs given: '%s'"
-msgstr "提供了超过两个数据（blob）对象：'%s'"
+msgstr "提供了超过两个数据对象：'%s'"
 
 #: builtin/diff.c:417
 #, c-format
@@ -5216,11 +5332,11 @@ msgstr "跳过数据对象的输出"
 
 #: builtin/fast-export.c:997
 msgid "refspec"
-msgstr "引用表达式"
+msgstr "引用规格"
 
 #: builtin/fast-export.c:998
 msgid "Apply refspec to exported refs"
-msgstr "对导出的引用应用引用表达式"
+msgstr "对导出的引用应用引用规格"
 
 #: builtin/fast-export.c:999
 msgid "anonymize output"
@@ -5228,7 +5344,7 @@ msgstr "匿名输出"
 
 #: builtin/fetch.c:19
 msgid "git fetch [<options>] [<repository> [<refspec>...]]"
-msgstr "git fetch [<选项>] [<版本库> [<引用规则>...]]"
+msgstr "git fetch [<选项>] [<仓库> [<引用规格>...]]"
 
 #: builtin/fetch.c:20
 msgid "git fetch [<options>] <group>"
@@ -5236,7 +5352,7 @@ msgstr "git fetch [<选项>] <组>"
 
 #: builtin/fetch.c:21
 msgid "git fetch --multiple [<options>] [(<repository> | <group>)...]"
-msgstr "git fetch --multiple [<选项>] [(<版本库> | <组>)...]"
+msgstr "git fetch --multiple [<选项>] [(<仓库> | <组>)...]"
 
 #: builtin/fetch.c:22
 msgid "git fetch --all [<options>]"
@@ -5297,7 +5413,7 @@ msgstr "深化浅克隆的历史"
 
 #: builtin/fetch.c:115
 msgid "convert to a complete repository"
-msgstr "转换为一个完整的版本库"
+msgstr "转换为一个完整的仓库"
 
 #: builtin/fetch.c:117 builtin/log.c:1208
 msgid "dir"
@@ -5430,7 +5546,7 @@ msgstr "（无）"
 #: builtin/fetch.c:822
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
-msgstr "拒绝获取到非纯版本库的当前分支 %s"
+msgstr "拒绝获取到非纯仓库的当前分支 %s"
 
 #: builtin/fetch.c:841
 #, c-format
@@ -5461,7 +5577,7 @@ msgstr "不能获取 %s"
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
-msgstr "未指定远程版本库。请通过一个URL或远程版本库名指定，用以获取新提交。"
+msgstr "未指定远程仓库。请通过一个URL或远程仓库名指定，用以获取新提交。"
 
 #: builtin/fetch.c:1106
 msgid "You need to specify a tag name."
@@ -5473,15 +5589,15 @@ msgstr "--depth 和 --unshallow 不能同时使用"
 
 #: builtin/fetch.c:1150
 msgid "--unshallow on a complete repository does not make sense"
-msgstr "对于一个完整的版本库，参数 --unshallow 没有意义"
+msgstr "对于一个完整的仓库，参数 --unshallow 没有意义"
 
 #: builtin/fetch.c:1173
 msgid "fetch --all does not take a repository argument"
-msgstr "fetch --all 不能带一个版本库参数"
+msgstr "fetch --all 不能带一个仓库参数"
 
 #: builtin/fetch.c:1175
 msgid "fetch --all does not make sense with refspecs"
-msgstr "fetch --all 带引用规则没有任何意义"
+msgstr "fetch --all 带引用规格没有任何意义"
 
 #: builtin/fetch.c:1186
 #, c-format
@@ -5490,7 +5606,7 @@ msgstr "没有这样的远程或远程组：%s"
 
 #: builtin/fetch.c:1194
 msgid "Fetching a group and specifying refspecs does not make sense"
-msgstr "获取组并指定引用规则没有意义"
+msgstr "获取组并指定引用规格没有意义"
 
 #: builtin/fmt-merge-msg.c:13
 msgid ""
@@ -5657,12 +5773,12 @@ msgstr "强制执行 gc 即使另外一个 gc 正在执行"
 #: builtin/gc.c:327
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
-msgstr "自动在后台执行版本库打包以求最佳性能。\n"
+msgstr "自动在后台执行仓库打包以求最佳性能。\n"
 
 #: builtin/gc.c:329
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
-msgstr "自动打包版本库以求最佳性能。\n"
+msgstr "自动打包仓库以求最佳性能。\n"
 
 #: builtin/gc.c:330
 #, c-format
@@ -6192,7 +6308,7 @@ msgstr "不能读取现存对象 %s"
 #: builtin/index-pack.c:825
 #, c-format
 msgid "invalid blob object %s"
-msgstr "无效的数据（blob）对象 %s"
+msgstr "无效的数据对象 %s"
 
 #: builtin/index-pack.c:839
 #, c-format
@@ -6451,7 +6567,7 @@ msgstr "不能移动 %s 至 %s"
 #: builtin/init-db.c:433
 #, c-format
 msgid "%s%s Git repository in %s%s\n"
-msgstr "%s%s Git 版本库于 %s%s\n"
+msgstr "%s%s Git 仓库于 %s%s\n"
 
 #: builtin/init-db.c:434
 msgid "Reinitialized existing"
@@ -6480,7 +6596,7 @@ msgstr "权限"
 
 #: builtin/init-db.c:506
 msgid "specify that the git repository is to be shared amongst several users"
-msgstr "指定 git 版本库是多个用户之间共享的"
+msgstr "指定 git 仓库是多个用户之间共享的"
 
 #: builtin/init-db.c:508 builtin/prune-packed.c:57 builtin/repack.c:171
 msgid "be quiet"
@@ -7149,7 +7265,7 @@ msgstr "没有当前分支。"
 
 #: builtin/merge.c:937
 msgid "No remote for the current branch."
-msgstr "当前分支没有对应的远程版本库。"
+msgstr "当前分支没有对应的远程仓库。"
 
 #: builtin/merge.c:939
 msgid "No default upstream defined for the current branch."
@@ -7394,7 +7510,7 @@ msgstr "目录 %s 在索引中并且不是子模组？"
 
 #: builtin/mv.c:71
 msgid "Please stage your changes to .gitmodules or stash them to proceed"
-msgstr "请将您的修改缓存到 .gitmodules 中或保存进度后再继续"
+msgstr "请将您的修改暂存到 .gitmodules 中或保存进度后再继续"
 
 #: builtin/mv.c:89
 #, c-format
@@ -7915,7 +8031,7 @@ msgstr "每个输出包的最大尺寸"
 
 #: builtin/pack-objects.c:2633
 msgid "ignore borrowed objects from alternate object store"
-msgstr "忽略从替代对象存储里借用对象"
+msgstr "忽略从备用对象存储里借用对象"
 
 #: builtin/pack-objects.c:2635
 msgid "ignore packed objects"
@@ -7999,7 +8115,7 @@ msgstr "创建精简包"
 
 #: builtin/pack-objects.c:2678
 msgid "create packs suitable for shallow fetches"
-msgstr "创建适合浅克隆版本库获取的包"
+msgstr "创建适合浅克隆仓库获取的包"
 
 #: builtin/pack-objects.c:2680
 msgid "ignore packs that have companion .keep file"
@@ -8063,7 +8179,7 @@ msgstr "使早于给定时间的对象过期"
 
 #: builtin/push.c:14
 msgid "git push [<options>] [<repository> [<refspec>...]]"
-msgstr "git push [<选项>] [<版本库> [<引用规则>...]]"
+msgstr "git push [<选项>] [<仓库> [<引用规格>...]]"
 
 #: builtin/push.c:85
 msgid "tag shorthand without <tag>"
@@ -8184,7 +8300,7 @@ msgstr ""
 "当 push.default 设置为 'matching' 后，git 将推送和远程同名的所有\n"
 "本地分支。\n"
 "\n"
-"从 Git 2.0 开始，Git 缺省采用更为保守的 'simple' 模式，只推送当前\n"
+"从 Git 2.0 开始，Git 默认采用更为保守的 'simple' 模式，只推送当前\n"
 "分支到远程关联的同名分支，即 'git push' 推送当前分支。\n"
 "\n"
 "参见 'git help config' 并查找 'push.default' 以获取更多信息。\n"
@@ -8194,7 +8310,7 @@ msgstr ""
 #: builtin/push.c:272
 msgid ""
 "You didn't specify any refspecs to push, and push.default is \"nothing\"."
-msgstr "您没有为推送指定任何引用规则，并且 push.default 为 \"nothing\"。"
+msgstr "您没有为推送指定任何引用规格，并且 push.default 为 \"nothing\"。"
 
 #: builtin/push.c:279
 msgid ""
@@ -8226,8 +8342,8 @@ msgid ""
 "(e.g., 'git pull ...') before pushing again.\n"
 "See the 'Note about fast-forwards' in 'git push --help' for details."
 msgstr ""
-"更新被拒绝，因为远程版本库包含您本地尚不存在的提交。这通常是因为另外\n"
-"一个版本库已向该引用进行了推送。再次推送前，您可能需要先整合远程变更\n"
+"更新被拒绝，因为远程仓库包含您本地尚不存在的提交。这通常是因为另外\n"
+"一个仓库已向该引用进行了推送。再次推送前，您可能需要先整合远程变更\n"
 "（如 'git pull ...'）。\n"
 "详见 'git push --help' 中的 'Note about fast-forwards' 小节。"
 
@@ -8257,7 +8373,7 @@ msgstr "无法推送一些引用到 '%s'"
 #: builtin/push.c:394
 #, c-format
 msgid "bad repository '%s'"
-msgstr "坏的版本库 '%s'"
+msgstr "坏的仓库 '%s'"
 
 #: builtin/push.c:395
 msgid ""
@@ -8272,11 +8388,11 @@ msgid ""
 "    git push <name>\n"
 msgstr ""
 "没有配置推送目标。\n"
-"或通过命令行指定URL，或用下面命令配置一个远程版本库\n"
+"或通过命令行指定URL，或用下面命令配置一个远程仓库\n"
 "\n"
 "    git remote add <名称> <地址>\n"
 "\n"
-"然后使用该远程版本库名执行推送\n"
+"然后使用该远程仓库名执行推送\n"
 "\n"
 "    git push <名称>\n"
 
@@ -8286,7 +8402,7 @@ msgstr "--all 和 --tags 不兼容"
 
 #: builtin/push.c:411
 msgid "--all can't be combined with refspecs"
-msgstr "--all 不能和引用规则同时使用"
+msgstr "--all 不能和引用规格同时使用"
 
 #: builtin/push.c:416
 msgid "--mirror and --tags are incompatible"
@@ -8294,7 +8410,7 @@ msgstr "--mirror 和 --tags 不兼容"
 
 #: builtin/push.c:417
 msgid "--mirror can't be combined with refspecs"
-msgstr "--mirror 不能和引用规则同时使用"
+msgstr "--mirror 不能和引用规格同时使用"
 
 #: builtin/push.c:422
 msgid "--all and --mirror are incompatible"
@@ -8302,7 +8418,7 @@ msgstr "--all 和 --mirror 不兼容"
 
 #: builtin/push.c:502
 msgid "repository"
-msgstr "版本库"
+msgstr "仓库"
 
 #: builtin/push.c:503
 msgid "push all refs"
@@ -8404,11 +8520,11 @@ msgstr "读取之余再执行一个合并"
 
 #: builtin/read-tree.c:119
 msgid "3-way merge if no file level merging required"
-msgstr "如果没有文件级合并需要，执行三路合并"
+msgstr "如果没有文件级合并需要，执行三方合并"
 
 #: builtin/read-tree.c:121
 msgid "3-way merge in presence of adds and removes"
-msgstr "存在添加和删除时，也执行三路合并"
+msgstr "存在添加和删除时，也执行三方合并"
 
 #: builtin/read-tree.c:123
 msgid "same as -m, but discard unmerged entries"
@@ -8609,7 +8725,7 @@ msgstr "无法设置 master '%s'"
 #: builtin/remote.c:335
 #, c-format
 msgid "Could not get fetch map for refspec %s"
-msgstr "无法得到引用规则 %s 的获取列表"
+msgstr "无法得到引用规格 %s 的获取列表"
 
 #: builtin/remote.c:436 builtin/remote.c:444
 msgid "(matching)"
@@ -8646,7 +8762,7 @@ msgid ""
 "\t%s\n"
 "\tPlease update the configuration manually if necessary."
 msgstr ""
-"没有更新非默认的获取引用规则\n"
+"没有更新非默认的获取引用规格\n"
 "\t%s\n"
 "\t如果必要请手动更新配置。"
 
@@ -9226,7 +9342,7 @@ msgstr "不能带路径进行%s重置。"
 #: builtin/reset.c:343
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
-msgstr "不能对纯版本库进行%s重置"
+msgstr "不能对纯仓库进行%s重置"
 
 #: builtin/reset.c:347
 msgid "-N can only be used with --mixed"
@@ -9407,8 +9523,8 @@ msgstr ""
 #: builtin/rm.c:239
 msgid "the following file has changes staged in the index:"
 msgid_plural "the following files have changes staged in the index:"
-msgstr[0] "如下文件相对索引区的内容有修改"
-msgstr[1] "如下文件相对索引区的内容有修改"
+msgstr[0] "下列文件索引中有变更"
+msgstr[1] "下列文件索引中有变更"
 
 #: builtin/rm.c:243 builtin/rm.c:254
 msgid ""
@@ -9609,7 +9725,7 @@ msgstr "不打印结果到标准输出（例如与 --verify 参数共用）"
 
 #: builtin/show-ref.c:187
 msgid "show refs from stdin that aren't in local repository"
-msgstr "显示从标准输入中读入的不在本地版本库中的引用"
+msgstr "显示从标准输入中读入的不在本地仓库中的引用"
 
 #: builtin/symbolic-ref.c:7
 msgid "git symbolic-ref [<options>] <name> [<ref>]"
@@ -10255,11 +10371,11 @@ msgstr "切换分支或恢复工作区文件"
 
 #: common-cmds.h:22
 msgid "Clone a repository into a new directory"
-msgstr "克隆一个版本库到一个新目录"
+msgstr "克隆一个仓库到一个新目录"
 
 #: common-cmds.h:23
 msgid "Record changes to the repository"
-msgstr "记录变更到版本库"
+msgstr "记录变更到仓库"
 
 #: common-cmds.h:24
 msgid "Show changes between commits, commit and working tree, etc"
@@ -10267,7 +10383,7 @@ msgstr "显示提交之间、提交和工作区之间等的差异"
 
 #: common-cmds.h:25
 msgid "Download objects and refs from another repository"
-msgstr "从另外一个版本库下载对象和引用"
+msgstr "从另外一个仓库下载对象和引用"
 
 #: common-cmds.h:26
 msgid "Print lines matching a pattern"
@@ -10275,7 +10391,7 @@ msgstr "输出和模式匹配的行"
 
 #: common-cmds.h:27
 msgid "Create an empty Git repository or reinitialize an existing one"
-msgstr "创建一个空的 Git 版本库或重新初始化一个已存在的版本库"
+msgstr "创建一个空的 Git 仓库或重新初始化一个已存在的仓库"
 
 #: common-cmds.h:28
 msgid "Show commit logs"
@@ -10291,7 +10407,7 @@ msgstr "移动或重命名一个文件、目录或符号链接"
 
 #: common-cmds.h:31
 msgid "Fetch from and integrate with another repository or a local branch"
-msgstr "获取并整合另外的版本库或一个本地分支"
+msgstr "获取并整合另外的仓库或一个本地分支"
 
 #: common-cmds.h:32
 msgid "Update remote refs along with associated objects"
@@ -10368,15 +10484,15 @@ msgstr ""
 
 #: git-am.sh:126
 msgid "Cannot fall back to three-way merge."
-msgstr "无法求助于三路合并。"
+msgstr "无法求助于三方合并。"
 
 #: git-am.sh:142
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
-msgstr "版本库缺乏必要的数据（blob）对象以进行三路合并。"
+msgstr "仓库缺乏必要的数据对象以进行三方合并。"
 
 #: git-am.sh:144
 msgid "Using index info to reconstruct a base tree..."
-msgstr "使用索引来重建一个（三路合并的）基础目录树..."
+msgstr "使用索引来重建一个（三方合并的）基础目录树..."
 
 #: git-am.sh:159
 msgid ""
@@ -10384,11 +10500,11 @@ msgid ""
 "It does not apply to blobs recorded in its index."
 msgstr ""
 "您是否曾手动编辑过您的补丁？\n"
-"无法应用补丁到索引中的数据（blob）对象上。"
+"无法应用补丁到索引中的数据对象上。"
 
 #: git-am.sh:168
 msgid "Falling back to patching base and 3-way merge..."
-msgstr "转而在基础版本上打补丁及进行三路合并..."
+msgstr "转而在基础版本上打补丁及进行三方合并..."
 
 #: git-am.sh:185
 msgid "Failed to merge in the changes."
@@ -10440,7 +10556,7 @@ msgstr "解决操作未进行，我们不会继续。"
 #: git-am.sh:635
 #, sh-format
 msgid "Dirty index: cannot apply patches (dirty: $files)"
-msgstr "脏的索引：不能应用补丁（脏文件：$files）"
+msgstr "脏索引：不能应用补丁（脏文件：$files）"
 
 #: git-am.sh:747
 #, sh-format
@@ -10855,7 +10971,7 @@ msgstr "变更从 $mb 到 $onto："
 
 #: git-rebase.sh:610
 msgid "First, rewinding head to replay your work on top of it..."
-msgstr "首先，重置头指针以便在上面重放您的工作..."
+msgstr "首先，回退分支以便在上面重放您的工作..."
 
 #: git-rebase.sh:620
 #, sh-format
@@ -10977,7 +11093,7 @@ msgstr "不能保存索引树"
 
 #: git-stash.sh:507
 msgid "Cannot unstage modified files"
-msgstr "无法还原修改的文件"
+msgstr "无法将修改的文件撤出暂存区"
 
 #: git-stash.sh:522
 msgid "Index was not unstashed."
@@ -11028,7 +11144,7 @@ msgstr "只能在工作区的顶级目录中使用相对路径"
 #: git-submodule.sh:416
 #, sh-format
 msgid "repo URL: '$repo' must be absolute or begin with ./|../"
-msgstr "版本库URL：'$repo' 必须是绝对路径或以 ./|../ 起始"
+msgstr "仓库URL：'$repo' 必须是绝对路径或以 ./|../ 起始"
 
 #: git-submodule.sh:433
 #, sh-format
@@ -11049,17 +11165,17 @@ msgstr ""
 #: git-submodule.sh:455
 #, sh-format
 msgid "Adding existing repo at '$sm_path' to the index"
-msgstr "添加位于 '$sm_path' 的现存版本库到索引"
+msgstr "添加位于 '$sm_path' 的现存仓库到索引"
 
 #: git-submodule.sh:457
 #, sh-format
 msgid "'$sm_path' already exists and is not a valid git repo"
-msgstr "'$sm_path' 已存在且不是一个有效的 git 版本库"
+msgstr "'$sm_path' 已存在且不是一个有效的 git 仓库"
 
 #: git-submodule.sh:465
 #, sh-format
 msgid "A git directory for '$sm_name' is found locally with remote(s):"
-msgstr "本地发现 '$sm_name' 的一个 git 目录，与其对应的远程版本库："
+msgstr "本地发现 '$sm_name' 的一个 git 目录，与其对应的远程仓库："
 
 #: git-submodule.sh:467
 #, sh-format
@@ -11071,7 +11187,7 @@ msgstr "如果您想重用此本地 git 目录而不是重新克隆自"
 #, sh-format
 msgid ""
 "use the '--force' option. If the local git directory is not the correct repo"
-msgstr "使用 '--force' 参数。如果本地 git 目录不是正确的版本库"
+msgstr "使用 '--force' 参数。如果本地 git 目录不是正确的仓库"
 
 #: git-submodule.sh:470
 #, sh-format


### PR DESCRIPTION
Add translations of Git glossary (most of them are from the command
`git help glossary`) in the header of `zh_CN.po`.  Also fixes some translations
according to this glossary, such as "pathspec", "repository", "refspec".

Signed-off-by: Jiang Xin worldhello.net@gmail.com
