### PR TITLE
Update Git Glossary

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -104,7 +104,7 @@
 #   revision                         |  版本
 #   rewind                           |  回退
 #   SCM                              |  源代码管理（工具）
-#   SHA-1                            |  安全哈希算法1
+#   SHA-1                            |  SHA-1（安全哈希算法1）
 #   shallow repository               |  浅（克隆）仓库
 #   signed tag                       |  签名标签
 #   smart HTTP                       |  智能 HTTP 协议

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -52,7 +52,7 @@
 #   fast-forward                     |  快进
 #   fetch                            |  获取
 #   file system                      |  文件系统
-#   fork                             |  派生，复刻
+#   fork                             |  派生
 #   Git archive                      |  仓库（对于 arch 用户）
 #   gitfile                          |  gitfile（仓库链接文件）
 #   grafts                           |  （提交）嫁接
@@ -7441,7 +7441,7 @@ msgstr "第一个是其他的祖先提交么？"
 
 #: builtin/merge-base.c:222
 msgid "find where <commit> forked from reflog of <ref>"
-msgstr "根据引用日志 <引用> 查找 <提交> 的派生处"
+msgstr "根据 <引用> 的引用日志查找 <提交> 的派生处"
 
 #: builtin/merge-file.c:8
 msgid ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -47,7 +47,7 @@
 #   detached HEAD                    |  分离头指针
 #   directory                        |  目录
 #   dirty                            |  脏（的工作区）
-#   dumb HTTP                        |  哑 HTTP 协议
+#   dumb HTTP protocol               |  哑 HTTP 协议
 #   evil merge                       |  坏合并（合并引入了父提交没有的修改）
 #   fast-forward                     |  快进
 #   fetch                            |  获取
@@ -107,7 +107,7 @@
 #   SHA-1                            |  SHA-1（安全哈希算法1）
 #   shallow repository               |  浅（克隆）仓库
 #   signed tag                       |  签名标签
-#   smart HTTP                       |  智能 HTTP 协议
+#   smart HTTP protocol              |  智能 HTTP 协议
 #   squash                           |  压缩
 #   stage                            |  n. 暂存区（即索引）; v. 暂存
 #   stash                            |  n. 进度保存; v. 保存进度

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -83,7 +83,7 @@
 #   patch                            |  补丁
 #   pathspec                         |  路径规格
 #   pattern                          |  模式
-#   pickaxe                          |  pickaxe
+#   pickaxe                          |  挖掘
 #   plumbing                         |  管件（Git 底层核心命令的别称）
 #   porcelain                        |  瓷件（Git 上层封装命令的别称）
 #   prune                            |  清除

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -113,7 +113,7 @@
 #   stash                            |  n. 进度保存; v. 保存进度
 #   submodule                        |  子模组
 #   symref                           |  符号引用
-#   tag                              |  标签
+#   tag                              |  n. 标签; v. 打标签
 #   tag object                       |  标签对象
 #   tagger                           |  打标签者
 #   topic branch                     |  主题分支


### PR DESCRIPTION
- l10n: zh_CN: Update Git Glossary: SHA-1
  
  It's quite common to see the term "SHA-1" remain untranslated in many
  l10n works.
  So update the "SHA-1" entry in Git glossary to match this behavior.
- l10n: zh_CN: Update Git Glossary: "dumb", "smart"
  
  "dumb/smart HTTP protocol" are normally considered as phrases.
  Add "protocol" as a suffix after them makes more sense.
- l10n: zh_CN: Update Git Glossary: tag
  
  Add verb form translation of tag.
- l10n: zh_CN: Update Git Glossary: fork
  
  Remove "复刻" from translation option list of "fork", leaving "派生"
  as the only one.
  
  In Git context, by talking about the term "fork", one usually mean the
  procedure that divides a branch into two or more history lines.  That
  is quite like the "fork" concept in programming, which split a process
  into two or more independent processes.
  
  On the other hand, "复刻" by itself means "copy" or "mirror".  It is
  considered more suitable for describing the procedure like
  "fork a repository", which is common on public repository hosting
  services, such as GitHub.  However, this is beyond the scope of
  core-Git.  As a l10n work for core-Git, "复刻" should be removed here.
  
  There used to be another option - "分岔".  Its a good idea to
  translate "fork point" as "分岔点".  However, "派生点" is as good,
  too.  So this option is finally discarded.
  
  Also fix a relevant translation issue which was introduced in
  160fb2b .
- l10n: zh_CN: Update Git Glossary: pickaxe
  
  Translate the term "pickaxe" as "挖掘".
  
  Initially proposed by @louy2 .
