### PR TITLE
l10n: zh_CN: fix typo of submodule init message

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -14072,7 +14072,7 @@ msgstr "无法为子模组 '%s' 注册 url"
 #: builtin/submodule--helper.c:515
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
-msgstr "子模组 '%s'（%s）未对路径 '%s' 注册\n"
+msgstr "子模组 '%s'（%s）已对路径 '%s' 注册\n"
 
 #
 #: builtin/submodule--helper.c:525


### PR DESCRIPTION
This patch somehow corrects a typo for `git submodule init`, which is
supposed to be mistakenly copyed from the `deinit` command

Signed-off-by: Zhilei Han <linusboyle@gmail.com>